### PR TITLE
Remove broken link to outdated deployment guide.

### DIFF
--- a/website/documentation.md
+++ b/website/documentation.md
@@ -4,7 +4,7 @@ hide:
   - toc
 ---
 
-The [documentation for OpenDNSSEC](https://opendnssec.readthedocs.io/) gives information on how to install, configure, and run OpenDNSSEC. Also in our docs we host a list of [frequently asked questions](https://opendnssec.readthedocs.io/en/latest/faq/). New users might be interested in our [OpenDNSSEC Initial Deployment Guide](https://www.opendnssec.org/wp-content/uploads/2009/06/opendnssec-start-guide.pdf).
+The [documentation for OpenDNSSEC](https://opendnssec.readthedocs.io/) gives information on how to install, configure, and run OpenDNSSEC. Also in our docs we host a list of [frequently asked questions](https://opendnssec.readthedocs.io/en/latest/faq/).
 
 ### SoftHSM
 


### PR DESCRIPTION
The link is broken and the only copy of the referenced document that I found was at https://web.archive.org/web/20160808131142/http://pletterpet.nl/static/pdf/opendnssec-start-guide.pdf which uses commands and instructions that are no longer correct for current OpenDNSSEC.